### PR TITLE
Fix crash when reconnect is clicked

### DIFF
--- a/app.js
+++ b/app.js
@@ -456,7 +456,11 @@ async function createMainWindow(show = false) {
   });
 
   // mainWindow.webContents.openDevTools();
-  await mainWindow.loadURL(indexFile);
+  try {
+    await mainWindow.loadURL(indexFile);
+  } catch (error) {
+    logger.info(error);
+  }
 
   createTray();
 
@@ -755,9 +759,9 @@ app.on('will-quit', () => {
 });
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+  // if (process.platform !== 'darwin') {
+  //   app.quit();
+  // }
 });
 
 ipcMain.on('get-instances', (event) => {


### PR DESCRIPTION
This PR fixes the issue that the app crashes when the "Reconnect" button is clicked. Related issues: #20 and #31

There are two underlying problems:
1. Uncaught error in https://github.com/iprodanovbg/homeassistant-desktop/blob/ec49f76c2abf450de94cf5ced17358177a2f1649/app.js#L459 I simply made the error caught but didn't "fix" it, which seems fine.
2. When the window is recreated through "Reconnect", the last window will be destroyed and thus https://github.com/iprodanovbg/homeassistant-desktop/blob/ec49f76c2abf450de94cf5ced17358177a2f1649/app.js#L757-L761 will be triggered and make the app silently quit. I disabled it. The "Quit" menu is not affected, and when clicked, the app should quit clean.

I only tested on Windows, so I'm not sure how this works on other platforms.