### PR TITLE
Separate Fullscreen Functionality from Shortcut Key Activation

### DIFF
--- a/app.js
+++ b/app.js
@@ -472,7 +472,11 @@ async function createMainWindow(show = false) {
   });
 
   // mainWindow.webContents.openDevTools();
-  await mainWindow.loadURL(indexFile);
+  try {
+    await mainWindow.loadURL(indexFile);
+  } catch (error) {
+    logger.info(error);
+  }
 
   createTray();
 
@@ -772,10 +776,10 @@ app.on('will-quit', () => {
   unregisterKeyboardShortcut();
 });
 
-app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
-    app.quit();
-  }
+app.on("window-all-closed", () => {
+  // if (process.platform !== "darwin") {
+  //   app.quit();
+  // }
 });
 
 ipcMain.on('get-instances', (event) => {

--- a/app.js
+++ b/app.js
@@ -734,7 +734,7 @@ app.whenReady().then(async () => {
     registerKeyboardShortcut();
   }
 
-  if (config.get("fullscreenShortcutEnabled")) {
+  if (config.get("shortcutFullscreenEnabled")) {
     globalShortcut.register("CommandOrControl+Alt+Return", () => {
       toggleFullScreen();
     });

--- a/app.js
+++ b/app.js
@@ -350,16 +350,15 @@ function getMenu() {
       },
     },
     {
-      label: 'Use Fullscreen',
-      type: 'checkbox',
-      checked: config.get('fullScreen'),
-      accelerator: 'CommandOrControl+Alt+Return',
+      label: "Use Fullscreen",
+      type: "checkbox",
+      checked: config.get("fullScreen"),
       click: () => {
         toggleFullScreen();
       },
     },
     {
-      type: 'separator',
+      label: "Enable Fullscreen Shortcut",
     },
     {
       label: `v${app.getVersion()}`,
@@ -735,9 +734,11 @@ app.whenReady().then(async () => {
     registerKeyboardShortcut();
   }
 
-  globalShortcut.register('CommandOrControl+Alt+Return', () => {
-    toggleFullScreen();
-  });
+  if (config.get("fullscreenShortcutEnabled")) {
+    globalShortcut.register("CommandOrControl+Alt+Return", () => {
+      toggleFullScreen();
+    });
+  }
 
   // disable hover for first start
   if (!config.has('currentInstance')) {

--- a/app.js
+++ b/app.js
@@ -359,6 +359,23 @@ function getMenu() {
     },
     {
       label: "Enable Fullscreen Shortcut",
+      type: "checkbox",
+      accelerator: "CommandOrControl+Alt+Return",
+      checked: config.get("shortcutFullscreenEnabled"),
+      click: () => {
+        const isEnabled = config.get("shortcutFullscreenEnabled");
+        config.set("shortcutFullscreenEnabled", !isEnabled);
+        if (!isEnabled) {
+          globalShortcut.register("CommandOrControl+Alt+Return", () => {
+            toggleFullScreen();
+          });
+        } else {
+          globalShortcut.unregister("CommandOrControl+Alt+Return");
+        }
+      },
+    },
+    {
+      type: "separator",
     },
     {
       label: `v${app.getVersion()}`,

--- a/config.js
+++ b/config.js
@@ -9,6 +9,7 @@ module.exports = new Store({
     stayOnTop: false,
     fullScreen: false,
     shortcutEnabled: false,
-    allInstances: []
-  }
+    shortcutFullscreenEnabled: false,
+    allInstances: [],
+  },
 });


### PR DESCRIPTION
Issue:
Previously, the application's fullscreen toggle was inherently linked to the Alt+Ctrl+Enter keyboard shortcut. This posed an issue where if the shortcut was already registered by another program, activating the shortcut would unintentionally trigger the fullscreen functionality in this application as well. Users experienced unintended behavior due to this global shortcut conflict.

Resolution:
To address this issue, this PR decouples the fullscreen toggle from the Alt+Ctrl+Enter shortcut. It introduces a new menu option that allows users to enable or disable the fullscreen shortcut independently of the fullscreen functionality itself.

Benefits:
This change improves the application's compatibility and prevents conflicts with other applications that might use the same global shortcut. 

## Screenshots:
Before:
![image](https://github.com/user-attachments/assets/7cebc37e-57d5-4bbe-bee4-3abba70ea973)
Atfter:
![image](https://github.com/user-attachments/assets/997da678-0559-4f6a-aa21-c1b58d58f5e4)